### PR TITLE
fix: validation - typo on trust_marks_issuers claims

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ Read the [setup documentation](docs/SETUP.md) to get started.
 ### Docker image
 
 ````
-docker pull ghcr.io/italia/spid-cie-oidc-django:v0.6.5
+docker pull ghcr.io/italia/spid-cie-oidc-django:v0.6.6
 ````
 
 ### Docker compose

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: "3"
 
 services:
   trust-anchor.org:
-    image: spid-cie-oidc-django:v0.6.5
+    image: spid-cie-oidc-django:v0.6.6
     build:
       context: .
       dockerfile: ./Dockerfile
@@ -19,7 +19,7 @@ services:
         python3 manage.py runserver 0.0.0.0:8000"
 
   cie-provider.org:
-    image: spid-cie-oidc-django:v0.6.5
+    image: spid-cie-oidc-django:v0.6.6
     build:
       context: .
       dockerfile: ./Dockerfile
@@ -40,7 +40,7 @@ services:
         python3 manage.py runserver 0.0.0.0:8002"
 
   relying-party.org:
-    image: spid-cie-oidc-django:v0.6.5
+    image: spid-cie-oidc-django:v0.6.6
     build:
       context: .
       dockerfile: ./Dockerfile

--- a/spid_cie_oidc/entity/statements.py
+++ b/spid_cie_oidc/entity/statements.py
@@ -240,7 +240,7 @@ class EntityConfiguration:
             raise MissingTrustMark("Required Trust marks are missing.") # pragma: no cover
 
         trust_mark_issuers_by_id = self.trust_anchor_entity_conf.payload.get(
-            "trust_mark_issuers", {}
+            "trust_marks_issuers", {}
         )
 
         # TODO : cache of issuers -> it would be better to have a proxy function


### PR DESCRIPTION
- [fix: [v0.6.6][trust marks] validation - typo on trust_marks_issuers claims](https://github.com/italia/spid-cie-oidc-django/commit/1c49edc15bc3eb862ac176cf86d64ac61fd0cb8d) 