### PR TITLE
BREAKING CHANGE: metadata policy and trust chan serialization

### DIFF
--- a/docs/FEDERATION_METADATA_POLICY.md
+++ b/docs/FEDERATION_METADATA_POLICY.md
@@ -31,7 +31,7 @@ metadata = {
 }
 
 policy = {
-    "scopes": {
+    "scope": {
         "default": ["openid"],
         "superset_of": ["openid"],
         "subset_of": ["openid", "offline_access", "profile", "email"],
@@ -57,7 +57,7 @@ apply_policy(metadata, policy)
  'redirect_uris': ['https://rp.example.it/spid/callback'],
  'response_types': ['code'],
  'subject_type': 'pairwise',
- 'scopes': ['openid']}
+ 'scope': ['openid']}
 ````
 
 Another example with OpenID Connect Provider

--- a/examples/federation_authority/dumps/example.json
+++ b/examples/federation_authority/dumps/example.json
@@ -560,7 +560,7 @@
               "refresh_token"
             ]
           },
-          "scopes": {
+          "scope": {
             "superset_of": [
               "openid"
             ],
@@ -724,7 +724,7 @@
                   "refresh_token"
                 ]
               },
-              "scopes": {
+              "scope": {
                 "superset_of": [
                   "openid"
                 ],
@@ -872,7 +872,7 @@
     ],
     "metadata_policy": {
       "openid_relying_party": {
-        "scopes": {
+        "scope": {
           "superset_of": [
             "openid"
           ],

--- a/examples/federation_authority/federation_authority/settingslocal.py.example
+++ b/examples/federation_authority/federation_authority/settingslocal.py.example
@@ -86,7 +86,7 @@ OIDCFED_DEFAULT_METADATA_POLICY = {
           "refresh_token"
          ]
       },
-      "scopes": {
+      "scope": {
         "superset_of": ["openid"],
         "subset_of": ["openid", "offline_access"]
     },

--- a/examples/provider/dumps/example.json
+++ b/examples/provider/dumps/example.json
@@ -398,7 +398,7 @@
       },
       "metadata_policy": {
         "openid_relying_party": {
-          "scopes": {
+          "scope": {
             "superset_of": [
               "openid"
             ],
@@ -534,7 +534,7 @@
               "refresh_token"
             ]
           },
-          "scopes": {
+          "scope": {
             "superset_of": [
               "openid"
             ],
@@ -698,7 +698,7 @@
                   "refresh_token"
                 ]
               },
-              "scopes": {
+              "scope": {
                 "superset_of": [
                   "openid"
                 ],
@@ -901,7 +901,7 @@
           },
           "metadata_policy": {
             "openid_relying_party": {
-              "scopes": {
+              "scope": {
                 "superset_of": [
                   "openid"
                 ],

--- a/spid_cie_oidc/authority/settings.py
+++ b/spid_cie_oidc/authority/settings.py
@@ -48,7 +48,7 @@ FEDERATION_DEFAULT_POLICY = getattr(
         },
         "openid_relying_party": {
             "grant_types": {"subset_of": ["authorization_code", "refresh_token"]},
-            "scopes": {
+            "scope": {
                 "superset_of": ["openid"],
                 "subset_of": ["openid", "offline_access"],
             },

--- a/spid_cie_oidc/authority/tests/settings.py
+++ b/spid_cie_oidc/authority/tests/settings.py
@@ -12,7 +12,7 @@ rp_onboarding_data = dict(
     name="RP Test",
     sub="http://rp-test.it/oidc/rp/",
     type="openid_relying_party",
-    metadata_policy={"openid_relying_party": {"scopes": {"value": ["openid"]}}},
+    metadata_policy={"openid_relying_party": {"scope": {"value": ["openid"]}}},
     is_active=True,
     jwks = [RP_METADATA_JWK1_pub]
 )
@@ -67,7 +67,7 @@ intermediary_onboarding_data = dict(
     name="intermediary-test",
     sub="http://intermediary-test",
     type="federation_entity",
-    # metadata_policy = {"openid_relying_party": {"scopes": {"value": ["openid"]}}},
+    # metadata_policy = {"openid_relying_party": {"scope": {"value": ["openid"]}}},
     is_active=True,
     jwks = [INTERMEDIARY_JWK1_pub]
 )

--- a/spid_cie_oidc/entity/tests/rp_metadata_settings.py
+++ b/spid_cie_oidc/entity/tests/rp_metadata_settings.py
@@ -18,7 +18,7 @@ RP_METADATA = {
           "https://rp.example.it/logo_small.jpg",
           "https://rp.example.it/logo_big.jpg"
     ],
-    "scopes" : ["openid", "offline_access", "profile"],
+    "scope" : ["openid", "offline_access", "profile"],
 }
 
 RP_METADATA_CIE = deepcopy(RP_METADATA)

--- a/spid_cie_oidc/entity/tests/test_05_policy.py
+++ b/spid_cie_oidc/entity/tests/test_05_policy.py
@@ -22,12 +22,12 @@ class PolicyTest(TestCase):
 
     def test_gather_polices_rp(self):
         combined_policy = gather_policies([{},rp_onboarding_data], "openid_relying_party")
-        self.assertTrue(combined_policy == {'scopes': {'value': ['openid']}})
+        self.assertTrue(combined_policy == {'scope': {'value': ['openid']}})
 
     def test_apply_policy(self):
         fa_policy = {}
-        fa_policy["scopes"] = FEDERATION_DEFAULT_POLICY["openid_relying_party"][
-            "scopes"
+        fa_policy["scope"] = FEDERATION_DEFAULT_POLICY["openid_relying_party"][
+            "scope"
         ]
         fa_policy["contacts"] = {"add": "ciao@email.it"}
         combined_policy = apply_policy(deepcopy(RP_METADATA), fa_policy)
@@ -43,15 +43,15 @@ class PolicyTest(TestCase):
 
     def test_apply_policy_subset_of(self):
         fa_policy = {}
-        fa_policy["scopes"] = {"subset_of": ["openid", "offline_access"]}
+        fa_policy["scope"] = {"subset_of": ["openid", "offline_access"]}
         combined_contacts = apply_policy(deepcopy(RP_METADATA), fa_policy)
-        self.assertTrue('profile' not in combined_contacts["scopes"])
+        self.assertTrue('profile' not in combined_contacts["scope"])
 
     def test_apply_policy_superset_of(self):
         fa_policy = {}
-        fa_policy["scopes"] = {"superset_of": ["openid"]}
+        fa_policy["scope"] = {"superset_of": ["openid"]}
         RP_METADATA_LOCAL = deepcopy(RP_METADATA)
-        RP_METADATA_LOCAL["scopes"] = ["offline_access"]
+        RP_METADATA_LOCAL["scope"] = ["offline_access"]
         with self.assertRaises(PolicyError):
             apply_policy(deepcopy(RP_METADATA_LOCAL), fa_policy)
 
@@ -82,8 +82,8 @@ class PolicyTest(TestCase):
 
     def test_diff_two_policy(self):
         fa_policy_old = {}
-        fa_policy_old["scopes"] = FEDERATION_DEFAULT_POLICY["openid_relying_party"][
-            "scopes"
+        fa_policy_old["scope"] = FEDERATION_DEFAULT_POLICY["openid_relying_party"][
+            "scope"
         ]
         fa_policy_new = deepcopy(fa_policy_old)
         fa_policy_new["contacts"] = {"add": "test@email.it"}


### PR DESCRIPTION
- BREAKING CHANGE: metadata policy, scopes to scope (https://github.com/italia/spid-cie-oidc-django/issues/115)
- chore: trust chain serialization and storage as signed jwt
