### PR TITLE
[bugifx] substitute pattern delimiter in docker-prepare.sh

### DIFF
--- a/docker-prepare.sh
+++ b/docker-prepare.sh
@@ -10,9 +10,9 @@ rm -f $EXPFOLDER/provider/db.sqlite3
 rm -f $EXPFOLDER/federation_authority/db.sqlite3 
 
 # Configure the rewrite rules:
-export SUB_AT='s\http://127.0.0.1:8000/\http://trust-anchor.org:8000/\g'
-export SUB_RP='s\http://127.0.0.1:8001/\http://relying-party.org:8001/\g'
-export SUB_OP='s\http://127.0.0.1:8002/\http://cie-provider.org:8002/\g'
+export SUB_AT='s,http://127.0.0.1:8000/,http://trust-anchor.org:8000/,g'
+export SUB_RP='s,http://127.0.0.1:8001/,http://relying-party.org:8001/,g'
+export SUB_OP='s,http://127.0.0.1:8002/,http://cie-provider.org:8002/,g'
 
 # Apply the rewrite rules:
 


### PR DESCRIPTION
Substitute patterns in `docker-prepare.sh` use backlashes as delimiters, but the default `sed` on Mac does not allow backslashes to be used as delimiters and emits the following error logs.

```console
$ ~/GitHub/italia/spid-cie-oidc-django$ which sed
/usr/bin/sed
$ ~/GitHub/italia/spid-cie-oidc-django$ bash docker-prepare.sh 
sed: 1: "s\http://127.0.0.1:8000 ...": substitute pattern can not be delimited by newline or backslash
sed: 1: "s\http://127.0.0.1:8000 ...": substitute pattern can not be delimited by newline or backslash
sed: 1: "s\http://127.0.0.1:8000 ...": substitute pattern can not be delimited by newline or backslash
sed: 1: "s\http://127.0.0.1:8000 ...": substitute pattern can not be delimited by newline or backslash
sed: 1: "s\http://127.0.0.1:8000 ...": substitute pattern can not be delimited by newline or backslash
sed: 1: "s\http://127.0.0.1:8000 ...": substitute pattern can not be delimited by newline or backslash
```