### PR TITLE
Fixing issue #256 - Open Redirect vulnerability

### DIFF
--- a/spid_cie_oidc/provider/views/consent_page_view.py
+++ b/spid_cie_oidc/provider/views/consent_page_view.py
@@ -106,7 +106,7 @@ def oidc_provider_not_consent(request):
         ),
         state = state
     )
-    url = f'{redirect_uri.path}?{urllib.parse.urlencode(kwargs)}'
+    url = f'{redirect_uri.path if redirect_uri.path else "/"}?{urllib.parse.urlencode(kwargs)}'
     return HttpResponseRedirect(url)
 
 

--- a/spid_cie_oidc/provider/views/consent_page_view.py
+++ b/spid_cie_oidc/provider/views/consent_page_view.py
@@ -1,6 +1,7 @@
 import logging
 from django.core.paginator import Paginator
 import urllib.parse
+from urllib.parse import urlparse
 
 from djagger.decorators import schema
 from django.contrib.auth import logout
@@ -95,7 +96,7 @@ class ConsentPageView(OpBase, View):
 
 
 def oidc_provider_not_consent(request):
-    redirect_uri = request.GET.get("redirect_uri")
+    redirect_uri = urlparse(request.GET.get("redirect_uri"))
     state = request.GET.get("state", "")
     logout(request)
     kwargs = dict(
@@ -105,7 +106,7 @@ def oidc_provider_not_consent(request):
         ),
         state = state
     )
-    url = f'{redirect_uri}?{urllib.parse.urlencode(kwargs)}'
+    url = f'{redirect_uri.path}?{urllib.parse.urlencode(kwargs)}'
     return HttpResponseRedirect(url)
 
 


### PR DESCRIPTION
This fixes the above-mentioned vulnerability. 

The "state" parameter should be intended as an anti XSRF mechanism and the application should check between the session-stored Anti XSRF token and the one provided in the state parameter passed during the authentication flow. This is not covered by this PR.

Note: this functionality is not tested and could break the existing [test case](https://github.com/italia/spid-cie-oidc-django/blob/45c4241e62db78e9a8d8e50a975b49709025c16b/spid_cie_oidc/provider/tests/test_10_no_consent.py) so, please, change it accordingly.