### PR TITLE
fix: openid-configuration endpoint not reachable

### DIFF
--- a/spid_cie_oidc/entity/views.py
+++ b/spid_cie_oidc/entity/views.py
@@ -145,7 +145,7 @@ def openid_jwks(request, metadata_type:str, resource_type:str):
         resource_tytpe = set(jwks_uri, jwks.jose)
     """
     _sub = request.build_absolute_uri().rsplit(resource_type)[0]
-    _lookup = _sub.replace(f"{metadata_type}/", "")
+    _lookup = _sub.replace(f"/{metadata_type}/", "")
     conf = FederationEntityConfiguration.objects.filter(
         # TODO: check for reverse proxy and forwarders ...
         sub=_lookup,

--- a/spid_cie_oidc/provider/views/connect.py
+++ b/spid_cie_oidc/provider/views/connect.py
@@ -18,7 +18,7 @@ def openid_configuration(request):
     OIDC Discovery configuration at
     .well-known/openid-configuration
     """
-    _sub = request.build_absolute_uri().split(".well-known/openid-configuration")[0]
+    _sub = request.build_absolute_uri().split("/.well-known/openid-configuration")[0]
     conf = FederationEntityConfiguration.objects.filter(
         # TODO: check for reverse proxy and forwarders ...
         sub=_sub,


### PR DESCRIPTION
The endpoint of the provider "/oidc/op/.well-known/openid-configuration" was always returning 404. There was an error in the splitting of the url that would never match the sub saved in the exaples/provider/dumps/example.json.
Same is for the jwks endpoint "oidc/op/<str:metadata_type>/jwks.json"