### PR TITLE
fix: aligned claims to trust_mark_issuers

### DIFF
--- a/docs/CREATE_A_FEDERATION.md
+++ b/docs/CREATE_A_FEDERATION.md
@@ -77,7 +77,7 @@ ta_conf_data = dict(
     metadata=FA_METADATA,
     constraints=FA_CONSTRAINTS,
     is_active=True,
-    trust_marks_issuers=TM_ISSUERS,
+    trust_mark_issuers=TM_ISSUERS,
 )
 
 FederationEntityConfiguration.objects.create(**ta_conf_data)

--- a/examples/federation_authority/dumps/example.json
+++ b/examples/federation_authority/dumps/example.json
@@ -177,7 +177,7 @@
       }
     ],
     "trust_marks": [],
-    "trust_marks_issuers": {
+    "trust_mark_issuers": {
       "https://www.spid.gov.it/certification/rp/public": [
         "https://registry.spid.agid.gov.it",
         "https://public.intermediary.spid.it"
@@ -253,7 +253,7 @@
         "trust_mark": "eyJhbGciOiJSUzI1NiIsImtpZCI6IkZpZll4MDNibm9zRDhtNmdZUUlmTkhOUDljTV9TYW05VGM1bkxsb0lJcmMifQ.eyJpc3MiOiJodHRwOi8vMTI3LjAuMC4xOjgwMDAvIiwic3ViIjoiaHR0cDovLzEyNy4wLjAuMTo4MDAwL29pZGMvcnAvIiwiaWF0IjoxNjQ1NjEyNDAxLCJpZCI6Imh0dHBzOi8vd3d3LnNwaWQuZ292Lml0L2NlcnRpZmljYXRpb24vcnAiLCJtYXJrIjoiaHR0cHM6Ly93d3cuYWdpZC5nb3YuaXQvdGhlbWVzL2N1c3RvbS9hZ2lkL2xvZ28uc3ZnIiwicmVmIjoiaHR0cHM6Ly9kb2NzLml0YWxpYS5pdC9pdGFsaWEvc3BpZC9zcGlkLXJlZ29sZS10ZWNuaWNoZS1vaWRjL2l0L3N0YWJpbGUvaW5kZXguaHRtbCJ9.mSPNR0AOPBn3UNJAIbrWUMQ8vGTetQajpa3i59JDKDXYWqo2TUGh4AQBghCiG3qqV9cl-hleLtuwoeZ1InKHeslTLftVdcR3meeMLs3mLobHYr26Mi7pC7-jx1ZFVyk4GXl7mn9WVSQGEUOiuhL01tdlUfxf0TJSFSOMEZGpCA3hXroLOnEl3FjkAw7sPvjfImsbadbHVusb72HTTs1n5Xo7z3As3fDWHcxD-fvvq0beu9cx-L2sT4YaNC-ELd1M3m5r0NIjjEUAt4Gnot-l5Z3-C_bA41uvh2hX34U_fGZ6jpmuluJo1Lqi26N8LTB-Rbu0UMaZnkRg9E72_YRZig"
       }
     ],
-    "trust_marks_issuers": {},
+    "trust_mark_issuers": {},
     "entity_type": "openid_relying_party",
     "metadata": {
       "federation_entity": {
@@ -343,7 +343,7 @@
       }
     ],
     "trust_marks": [],
-    "trust_marks_issuers": {},
+    "trust_mark_issuers": {},
     "entity_type": "openid_provider",
     "metadata": {
       "federation_entity": {
@@ -543,7 +543,7 @@
           "federation_list_endpoint": "http://127.0.0.1:8000/list"
         }
       },
-      "trust_marks_issuers": {
+      "trust_mark_issuers": {
         "https://www.spid.gov.it/certification/rp/public": [
           "https://registry.spid.agid.gov.it",
           "https://public.intermediary.spid.it"

--- a/examples/provider/dumps/example.json
+++ b/examples/provider/dumps/example.json
@@ -142,7 +142,7 @@
       }
     ],
     "trust_marks": [],
-    "trust_marks_issuers": {},
+    "trust_mark_issuers": {},
     "entity_type": "openid_provider",
     "metadata": {
       "federation_entity": {
@@ -340,7 +340,7 @@
           "federation_list_endpoint": "http://127.0.0.1:8000/list"
         }
       },
-      "trust_marks_issuers": {
+      "trust_mark_issuers": {
         "https://www.spid.gov.it/certification/rp/public": [
           "https://registry.spid.agid.gov.it",
           "https://public.intermediary.spid.it"

--- a/examples/relying_party/dumps/example.json
+++ b/examples/relying_party/dumps/example.json
@@ -60,7 +60,7 @@
         "trust_mark": "eyJhbGciOiJSUzI1NiIsImtpZCI6IkZpZll4MDNibm9zRDhtNmdZUUlmTkhOUDljTV9TYW05VGM1bkxsb0lJcmMifQ.eyJpc3MiOiJodHRwOi8vMTI3LjAuMC4xOjgwMDAvIiwic3ViIjoiaHR0cDovLzEyNy4wLjAuMTo4MDAwL29pZGMvcnAvIiwiaWF0IjoxNjQ1NjEyNDAxLCJpZCI6Imh0dHBzOi8vd3d3LnNwaWQuZ292Lml0L2NlcnRpZmljYXRpb24vcnAiLCJtYXJrIjoiaHR0cHM6Ly93d3cuYWdpZC5nb3YuaXQvdGhlbWVzL2N1c3RvbS9hZ2lkL2xvZ28uc3ZnIiwicmVmIjoiaHR0cHM6Ly9kb2NzLml0YWxpYS5pdC9pdGFsaWEvc3BpZC9zcGlkLXJlZ29sZS10ZWNuaWNoZS1vaWRjL2l0L3N0YWJpbGUvaW5kZXguaHRtbCJ9.mSPNR0AOPBn3UNJAIbrWUMQ8vGTetQajpa3i59JDKDXYWqo2TUGh4AQBghCiG3qqV9cl-hleLtuwoeZ1InKHeslTLftVdcR3meeMLs3mLobHYr26Mi7pC7-jx1ZFVyk4GXl7mn9WVSQGEUOiuhL01tdlUfxf0TJSFSOMEZGpCA3hXroLOnEl3FjkAw7sPvjfImsbadbHVusb72HTTs1n5Xo7z3As3fDWHcxD-fvvq0beu9cx-L2sT4YaNC-ELd1M3m5r0NIjjEUAt4Gnot-l5Z3-C_bA41uvh2hX34U_fGZ6jpmuluJo1Lqi26N8LTB-Rbu0UMaZnkRg9E72_YRZig"
       }
     ],
-    "trust_marks_issuers": {},
+    "trust_mark_issuers": {},
     "entity_type": "openid_relying_party",
     "metadata": {
       "federation_entity": {
@@ -159,7 +159,7 @@
           "federation_list_endpoint": "http://127.0.0.1:8000/list"
         }
       },
-      "trust_marks_issuers": {
+      "trust_mark_issuers": {
         "https://www.spid.gov.it/certification/rp/public": [
           "https://registry.spid.agid.gov.it",
           "https://public.intermediary.spid.it"

--- a/examples/wallet_trust_anchor/dumps/ta-ec.json
+++ b/examples/wallet_trust_anchor/dumps/ta-ec.json
@@ -23,7 +23,7 @@
       ],
       "jwks_core": [],
       "trust_marks": [],
-      "trust_marks_issuers": {},
+      "trust_mark_issuers": {},
       "entity_type": "federation_entity",
       "metadata": {
         "federation_entity": {

--- a/spid_cie_oidc/entity/migrations/0001_initial.py
+++ b/spid_cie_oidc/entity/migrations/0001_initial.py
@@ -77,7 +77,7 @@ class Migration(migrations.Migration):
                     ),
                 ),
                 (
-                    "trust_marks_issuers",
+                    "trust_mark_issuers",
                     models.JSONField(
                         blank=True,
                         default=dict,

--- a/spid_cie_oidc/entity/models.py
+++ b/spid_cie_oidc/entity/models.py
@@ -97,7 +97,7 @@ class FederationEntityConfiguration(TimeStampedModel):
         help_text=_("which trust marks MUST be exposed in its entity configuration"),
         default=list,
     )
-    trust_marks_issuers = models.JSONField(
+    trust_mark_issuers = models.JSONField(
         blank=True,
         help_text=_(
             "Only usable for Trust Anchors and intermediates. "
@@ -219,8 +219,8 @@ class FederationEntityConfiguration(TimeStampedModel):
             "metadata": self.metadata,
         }
 
-        if self.trust_marks_issuers:
-            conf["trust_marks_issuers"] = self.trust_marks_issuers
+        if self.trust_mark_issuers:
+            conf["trust_mark_issuers"] = self.trust_mark_issuers
 
         if self.trust_marks:
             conf["trust_marks"] = self.trust_marks

--- a/spid_cie_oidc/entity/statements.py
+++ b/spid_cie_oidc/entity/statements.py
@@ -239,7 +239,7 @@ class EntityConfiguration:
             raise MissingTrustMark("Required Trust marks are missing.") # pragma: no cover
 
         trust_mark_issuers_by_id = self.trust_anchor_entity_conf.payload.get(
-            "trust_marks_issuers", {}
+            "trust_mark_issuers", {}
         )
 
         # TODO : cache of issuers -> it would be better to have a proxy function

--- a/spid_cie_oidc/entity/tests/settings.py
+++ b/spid_cie_oidc/entity/tests/settings.py
@@ -26,7 +26,7 @@ ta_conf_data = dict(
     metadata=FA_METADATA,
     constraints=FA_CONSTRAINTS,
     is_active=1,
-    trust_marks_issuers=TM_ISSUERS,
+    trust_mark_issuers=TM_ISSUERS,
 )
 TA_JWK_PRIVATE = {'kty': 'RSA', 'n': 'w8H80eT2zrs2XQ-SApZG9TkuXDuIxANfCVHt4fFqNnOEZaCNWqlTQIo0JiSBE-QmzZ09TYP1BJpESuQf_PUeLRVPfYHsBVk5OYvhT27_nYlV7_1LsFGLxxsIa-hswMMzvW-1_huKLy6Fp0WP0ouUJAHsF_eYVtO1ApRhvlIVd5azM4k7t8Lh8lkCSdF1SfGHfXnXJRb-XensZ0cFSfe2Koq9mD7jpGLXlPpXxj8Ow0g7KYT5kVtWE5ULmNmO7BIN1Hx4HpggbbEGgC9FyjKw4GfFb-csnB-icBPf_60HomjrkFFt6vTjrcqQaHOj-sEjP36N8rMSBiMmiMSPnsHhMQ', 'e': 'AQAB', 'd': 'jEDxjcTZXBbgBV8Bgt7-qfW1FJoHDEFKFxhfMpHQQoETa-jTPhCxOD2MzYM8A-9kKc8tu9r-crTAl1PI42kPnMd283phixd5G5Tv8gSaGdnq-45ka0iRuC7TItUdDiMNb_2YzB4ZLGLNmaIKQJSGqCHEcQuRVyxJtTZwrXaMMOhDqJaWUvUQWF5C7g5O5mOVTkNKw6ujzhqcWa4N3NE-HwcbVW_9st4s1c_ng-DlwLTptaeM5j-LOeZMX1zcVlwYMi5ZkYYY6FHHjYI4nBWDtqhvf-64QaTv8exIjk8PcxHOwhfLTWiHPLk14af7U_pCzkP87WQCBgNfvt3WILQ5DQ', 'p': '75eNHkWaYQMgzVfFwif5uftSxqOhFU6VkxNKdqoRuFxJuVTO-M-vbQc3BwPxms2xrpizU6zGcoPGPvccDi0G040wZh34pWDVABMgGMKXKmeTwj8FuM1DzOVq8DKHmdrhk1gaQbPAP8JVOVYK7uh_lG5wmz3X-En1McMk-E8g8Ic', 'q': '0Sny6DLNtDP1_B9qiyCaMtRqPSAUZ1ohCZRlBT6-IGRR31Kt5S2JcVNDnF5w4dunlDY4nhIBZ0v0VyzWKgDXj6qrFY1pm1iE29gW227YsVRWQU8xWGpBwEu8nxNMr0u0zfe0QEGWU4RvNAsZPRa31HU87Vm7I3NSZ34DZsCZJoc', 'kid': 'HIvo33-Km7n03ZqKDJfWVnlFudsW28YhQZx5eaXtAKA'}
 TA_JWK_PUBLIC = {'kty': 'RSA', 'n': 'w8H80eT2zrs2XQ-SApZG9TkuXDuIxANfCVHt4fFqNnOEZaCNWqlTQIo0JiSBE-QmzZ09TYP1BJpESuQf_PUeLRVPfYHsBVk5OYvhT27_nYlV7_1LsFGLxxsIa-hswMMzvW-1_huKLy6Fp0WP0ouUJAHsF_eYVtO1ApRhvlIVd5azM4k7t8Lh8lkCSdF1SfGHfXnXJRb-XensZ0cFSfe2Koq9mD7jpGLXlPpXxj8Ow0g7KYT5kVtWE5ULmNmO7BIN1Hx4HpggbbEGgC9FyjKw4GfFb-csnB-icBPf_60HomjrkFFt6vTjrcqQaHOj-sEjP36N8rMSBiMmiMSPnsHhMQ', 'e': 'AQAB', 'kid': 'HIvo33-Km7n03ZqKDJfWVnlFudsW28YhQZx5eaXtAKA'}
@@ -40,5 +40,5 @@ ta_conf_data_as_json = dict(
     },
     constraints=FA_CONSTRAINTS,
     is_active=1,
-    trust_marks_issuers=TM_ISSUERS,
+    trust_mark_issuers=TM_ISSUERS,
 )

--- a/spid_cie_oidc/provider/tests/settings.py
+++ b/spid_cie_oidc/provider/tests/settings.py
@@ -16,7 +16,7 @@ op_conf = {
     "jwks_fed": [op_conf_priv_jwk],
     "jwks_core": [op_conf_priv_jwk],
     "trust_marks": [],
-    "trust_marks_issuers": {},
+    "trust_mark_issuers": {},
     "entity_type": "openid_provider",
     "metadata": {
         "openid_provider": {


### PR DESCRIPTION
renamed every  "trust_mark_issuer", "trust_marks_issuers" to **trust_mark_issuers** as stated in https://bitbucket.org/openid/connect/issues/2081/inconsistent-trust-mark-identifier-names