### PR TITLE
fix code_verifier length

### DIFF
--- a/spid_cie_oidc/relying_party/utils.py
+++ b/spid_cie_oidc/relying_party/utils.py
@@ -2,9 +2,8 @@ import base64
 import json
 import hashlib
 import logging
-import os
 import random
-import re
+import secrets
 import string
 import urllib
 
@@ -34,10 +33,11 @@ def random_string(n=32):
 def get_pkce(code_challenge_method: str = "S256", code_challenge_length: int = 64):
     hashers = {"S256": hashlib.sha256}
 
-    code_verifier_length = random.randint(43, 128) # nosec - B311
-    code_verifier = base64.urlsafe_b64encode(os.urandom(code_verifier_length)).decode("utf-8")
-    code_verifier = re.sub("[^a-zA-Z0-9]+", "", code_verifier)
-
+    # https://datatracker.ietf.org/doc/html/rfc7636#section-4.1
+    code_verifier_length = secrets.choice(range(43, 128 + 1))
+    alpha = string.ascii_letters + string.digits + "-._~"
+    code_verifier = "".join([secrets.choice(alpha) for _ in range(code_verifier_length)])
+    
     code_challenge = hashers.get(code_challenge_method)(
         code_verifier.encode("utf-8")
     ).digest()


### PR DESCRIPTION
In the current implementation, `code_verifier` can exceed the length limits defined in the specification (43-128) because, once the byte string of the correct length is defined, it is base64 encoded to comply with the accepted character constraint, which increases its length.

An alternative implementation, as in:
https://github.com/RomeoDespres/pkce/blob/master/pkce/__init__.py#L19
could be
```
code_verifier = secrets.token_urlsafe(96)[:length]
```
