### PR TITLE
Prevent SSRF from unverified authorization requests (CWE-918)

### DIFF
--- a/spid_cie_oidc/entity/network_utils.py
+++ b/spid_cie_oidc/entity/network_utils.py
@@ -1,0 +1,70 @@
+"""
+Helpers to keep federation network operations from being turned into an SSRF /
+open-proxy primitive.
+
+An OpenID Federation endpoint resolves trust chains by fetching entity
+configurations over HTTP. When the subject of such a fetch comes from an
+unauthenticated, not-yet-verified request, an attacker can point it at an
+address of their choosing. These helpers let callers refuse addresses that must
+never be reached this way (loopback, private, link-local incl. the cloud
+metadata address, ...) and non-HTTP(S) schemes.
+"""
+
+import ipaddress
+import socket
+from urllib.parse import urlparse
+
+
+def is_public_ip(ip: str) -> bool:
+    """Return True only for a globally routable IP address."""
+    try:
+        addr = ipaddress.ip_address(ip)
+    except ValueError:
+        return False
+
+    # ip_address.is_global is False for private, loopback, link-local,
+    # unspecified, reserved and multicast ranges (incl. 169.254.169.254 and
+    # 100.64.0.0/10 CGNAT).
+    if isinstance(addr, ipaddress.IPv6Address) and addr.ipv4_mapped is not None:
+        addr = addr.ipv4_mapped
+
+    return addr.is_global
+
+
+def is_fetchable_federation_url(url: str) -> bool:
+    """
+    Return True only if ``url`` is an http(s) URL whose host is safe to fetch:
+    a public IP literal, or a hostname that resolves exclusively to public
+    addresses. Resolving here (and rejecting on any non-public answer) also
+    blocks DNS-rebinding style bypasses.
+    """
+    try:
+        parsed = urlparse(url)
+    except ValueError:
+        return False
+
+    if parsed.scheme not in ("http", "https"):
+        return False
+
+    host = parsed.hostname
+    if not host:
+        return False
+
+    # Host given as an IP literal: classify it directly.
+    try:
+        ipaddress.ip_address(host)
+        return is_public_ip(host)
+    except ValueError:
+        pass
+
+    # Host given as a name: every resolved address must be public.
+    try:
+        infos = socket.getaddrinfo(host, parsed.port or 0, proto=socket.IPPROTO_TCP)
+    except socket.gaierror:
+        return False
+
+    resolved = {info[4][0] for info in infos}
+    if not resolved:
+        return False
+
+    return all(is_public_ip(ip) for ip in resolved)

--- a/spid_cie_oidc/entity/tests/test_ssrf_network_utils.py
+++ b/spid_cie_oidc/entity/tests/test_ssrf_network_utils.py
@@ -1,0 +1,65 @@
+from unittest.mock import patch
+
+from django.test import TestCase
+
+from spid_cie_oidc.entity.network_utils import (
+    is_fetchable_federation_url,
+    is_public_ip,
+)
+
+
+class SSRFNetworkUtilsTest(TestCase):
+    def test_is_public_ip(self):
+        public = ["8.8.8.8", "1.1.1.1", "93.184.216.34", "2001:4860:4860::8888"]
+        blocked = [
+            "127.0.0.1",       # loopback
+            "10.0.0.1",        # private
+            "192.168.1.1",     # private
+            "172.16.0.1",      # private
+            "169.254.169.254",  # link-local / cloud metadata
+            "100.64.0.1",      # CGNAT
+            "0.0.0.0",         # unspecified
+            "::1",             # IPv6 loopback
+            "fc00::1",         # IPv6 ULA
+            "fe80::1",         # IPv6 link-local
+            "not-an-ip",
+        ]
+        for ip in public:
+            self.assertTrue(is_public_ip(ip), ip)
+        for ip in blocked:
+            self.assertFalse(is_public_ip(ip), ip)
+
+    def test_fetchable_url_scheme_and_ip_literal(self):
+        # Non http(s) schemes are refused.
+        self.assertFalse(is_fetchable_federation_url("ftp://example.com/x"))
+        self.assertFalse(is_fetchable_federation_url("file:///etc/passwd"))
+        self.assertFalse(is_fetchable_federation_url("gopher://127.0.0.1/"))
+
+        # IP-literal hosts are classified without DNS.
+        self.assertTrue(is_fetchable_federation_url("https://8.8.8.8/.well-known/openid-federation"))
+        self.assertFalse(is_fetchable_federation_url("http://127.0.0.1/.well-known/openid-federation"))
+        self.assertFalse(is_fetchable_federation_url("http://169.254.169.254/latest/meta-data/"))
+        self.assertFalse(is_fetchable_federation_url("http://[::1]/x"))
+
+    def test_fetchable_url_hostname_resolution(self):
+        # A hostname resolving to a public address is allowed...
+        with patch("socket.getaddrinfo", return_value=[(2, 1, 6, "", ("93.184.216.34", 443))]):
+            self.assertTrue(is_fetchable_federation_url("https://rp.example.org/"))
+
+        # ...one resolving (even partly) to an internal address is refused.
+        with patch("socket.getaddrinfo", return_value=[(2, 1, 6, "", ("127.0.0.1", 80))]):
+            self.assertFalse(is_fetchable_federation_url("http://sneaky.example/"))
+        with patch(
+            "socket.getaddrinfo",
+            return_value=[
+                (2, 1, 6, "", ("93.184.216.34", 443)),
+                (2, 1, 6, "", ("10.0.0.5", 443)),
+            ],
+        ):
+            self.assertFalse(is_fetchable_federation_url("https://rebind.example/"))
+
+        # Unresolvable host is refused.
+        import socket
+
+        with patch("socket.getaddrinfo", side_effect=socket.gaierror):
+            self.assertFalse(is_fetchable_federation_url("https://nxdomain.invalid/"))

--- a/spid_cie_oidc/provider/tests/test_13_authz_ssrf.py
+++ b/spid_cie_oidc/provider/tests/test_13_authz_ssrf.py
@@ -1,0 +1,71 @@
+from unittest.mock import MagicMock, patch
+
+from django.contrib.auth import get_user_model
+from django.test import Client, TestCase, override_settings
+from django.urls import reverse
+
+from spid_cie_oidc.authority.tests.settings import RP_METADATA_JWK1
+from spid_cie_oidc.entity.jwtse import create_jws
+from spid_cie_oidc.entity.models import FederationEntityConfiguration, FetchedEntityStatement
+from spid_cie_oidc.entity.tests.settings import TA_SUB
+from spid_cie_oidc.entity.utils import datetime_from_timestamp, exp_from_now, iat_now
+from spid_cie_oidc.provider.tests.settings import op_conf
+from spid_cie_oidc.relying_party.utils import random_string
+
+# An attacker-chosen subject that is NOT part of the federation (no trust chain
+# exists for it in the database).
+ATTACKER_SUB = "https://attacker.example/oidc/rp/"
+
+
+class AuthzRequestSSRFTest(TestCase):
+    """
+    An unauthenticated authorization request must not be able to make the OP
+    fetch an arbitrary URL: on-the-fly trust chain discovery is only allowed for
+    subjects already known inside the federation (CWE-918).
+    """
+
+    def setUp(self):
+        self.user = get_user_model().objects.create(username="test", email="test@test.it")
+        self.user.set_password("test")
+        self.user.save()
+        self.op_conf = FederationEntityConfiguration.objects.create(**op_conf)
+        self.ta_fes = FetchedEntityStatement.objects.create(
+            sub=TA_SUB,
+            iss=TA_SUB,
+            exp=datetime_from_timestamp(exp_from_now(33)),
+            iat=datetime_from_timestamp(iat_now()),
+        )
+        self.payload = {
+            "client_id": ATTACKER_SUB,
+            "sub": ATTACKER_SUB,
+            "iss": ATTACKER_SUB,
+            "response_type": "code",
+            "scope": ["openid"],
+            "nonce": random_string(),
+            "prompt": "consent login",
+            "redirect_uri": f"{ATTACKER_SUB}callback/",
+            "acr_values": ["https://www.spid.gov.it/SpidL2"],
+            "state": random_string(),
+            "aud": ["https://op.spid.agid.gov.it/auth"],
+            "iat": iat_now(),
+            "exp": exp_from_now(),
+            "jti": random_string(),
+        }
+
+    @override_settings(OIDCFED_TRUST_ANCHORS=[TA_SUB])
+    def test_unknown_subject_does_not_trigger_outbound_fetch(self):
+        jws = create_jws(self.payload, RP_METADATA_JWK1)
+        client = Client()
+        url = reverse("oidc_provider_authnrequest")
+
+        with patch(
+            "spid_cie_oidc.provider.views.get_or_create_trust_chain",
+            new=MagicMock(name="get_or_create_trust_chain"),
+        ) as mocked_discovery:
+            res = client.get(url, {"request": jws})
+
+        # The server refused the request instead of building a trust chain, and
+        # crucially it did NOT perform any outbound discovery fetch.
+        mocked_discovery.assert_not_called()
+        self.assertEqual(res.status_code, 302)
+        self.assertIn("error", res.url)

--- a/spid_cie_oidc/provider/views/__init__.py
+++ b/spid_cie_oidc/provider/views/__init__.py
@@ -9,6 +9,7 @@ from django.utils import timezone
 import urllib
 from spid_cie_oidc.entity.jwtse import create_jws, unpad_jwt_head, unpad_jwt_payload, verify_jws
 from spid_cie_oidc.entity.models import FederationEntityConfiguration, TrustChain
+from spid_cie_oidc.entity.network_utils import is_fetchable_federation_url
 from spid_cie_oidc.entity.settings import HTTPC_PARAMS
 from spid_cie_oidc.entity.trust_chain_operations import get_or_create_trust_chain
 from spid_cie_oidc.entity.utils import datetime_from_timestamp, exp_from_now, iat_now
@@ -85,6 +86,29 @@ class OpBase:
             raise Exception(_msg)
 
         elif not rp_trust_chain or rp_trust_chain.is_expired:
+            # A trust chain may be (re)built on the fly ONLY for a subject we
+            # already know inside our federation. `self.payload["iss"]` here
+            # comes from a request object whose signature has NOT been verified
+            # yet (its verifying key is only obtained through the trust chain
+            # below), so rebuilding a chain for an arbitrary iss would let any
+            # unauthenticated caller coerce this server into issuing outbound
+            # requests to a URL of their choosing - SSRF / request laundering.
+            # New relying parties are onboarded and fetched out of band, not
+            # discovered from an incoming authorization request.
+            known_subject = TrustChain.objects.filter(
+                sub=self.payload["iss"],
+                trust_anchor__sub__in=settings.OIDCFED_TRUST_ANCHORS,
+            ).exists()
+            if not known_subject or not is_fetchable_federation_url(self.payload["iss"]):
+                _msg = (
+                    "Refusing on-the-fly trust chain discovery for unknown or "
+                    f"unsafe subject {self.payload['iss']}. "
+                    "error=unauthorized_client, "
+                    f"state={state}"
+                )
+                logger.warning(_msg)
+                raise Exception(_msg)
+
             rp_trust_chain = None
             # TODO: get async here
             for ta in settings.OIDCFED_TRUST_ANCHORS:


### PR DESCRIPTION
## Vulnerability (CWE-918 SSRF / request laundering — medium)

The OP **authorization endpoint** (`AuthzRequestView.get`, a plain unauthenticated `View`) processes the incoming request object *before* its signature is verified. In `OpBase.validate_authz_request_object`:

```python
self.payload = unpad_jwt_payload(req)      # decode only, NOT verified
...
elif not rp_trust_chain or rp_trust_chain.is_expired:
    for ta in settings.OIDCFED_TRUST_ANCHORS:
        rp_trust_chain = get_or_create_trust_chain(
            subject=self.payload["iss"],   # attacker-controlled
            trust_anchor=ta, httpc_params=HTTPC_PARAMS, ...
        )                                  # <-- outbound HTTP fetch
...
verify_jws(req, jwk)                        # signature only checked here, later
```

`iss` is taken from the unverified request, so an unauthenticated attacker can point it at any URL and make the server issue an outbound request to it (`.well-known/openid-federation` and up the chain) — usable to reach internal services or to **mask the origin** of an attack against third parties. The signature is only verified afterwards, once the RP's keys have been fetched.

## Fix

On-the-fly trust chain discovery is now allowed **only for a subject already known inside the federation** — one for which a trust chain anchored to one of our `OIDCFED_TRUST_ANCHORS` already exists. Unknown or unsafe subjects are refused *before any network call*. New relying parties are onboarded and fetched out of band (`fetch_openid_relying_parties`), consistently with the `resolve` endpoint, which already refuses to trigger discovery from unauthenticated input.

As defence in depth, `spid_cie_oidc/entity/network_utils.py` adds `is_fetchable_federation_url()`, rejecting non-`http(s)` schemes and any host — IP literal or resolved hostname — that is loopback, private, link-local (incl. `169.254.169.254`), CGNAT or otherwise non-global (also blocking DNS-rebinding, since every resolved address must be public).

## Tests

- `provider/tests/test_13_authz_ssrf.py`: an authorization request with an attacker-chosen `iss` that is not part of the federation triggers **no** `get_or_create_trust_chain` call (asserted via mock) and is refused.
- `entity/tests/test_ssrf_network_utils.py`: `is_public_ip` / `is_fetchable_federation_url` classification for public vs loopback/private/link-local/CGNAT/ULA hosts, scheme filtering, and DNS-resolution cases.

## Verification

Full suite in a `python:3.13-slim` container: **284 tests, all green**. `flake8` and `bandit -ll` clean on the changed files.
